### PR TITLE
fixed issed #34 : minPoint and maxPoint not properly mapped in dataformatter.cpp

### DIFF
--- a/inc/dataformatter.h
+++ b/inc/dataformatter.h
@@ -25,7 +25,7 @@ public:
 
     void FindMinMax(const uvc_frame_t *input, QPoint &minPoint, uint16_t &minVal, QPoint &maxPoint, uint16_t &maxVal) const;
     void AutoGain(uvc_frame_t *input_output);
-    void FixedGain(uvc_frame_t *input_output, ushort minval, ushort maxval);
+    void FixedGain(uvc_frame_t *input_output, QPoint minpoint, ushort minval, QPoint maxpoint, ushort maxval);
     void Colorize(const uvc_frame_t *input, QVideoFrame &output) const;
 
     static const colormap_t* getPalette(Palette palette);
@@ -36,16 +36,25 @@ public:
     Q_PROPERTY(ushort maxVal READ getMaxVal NOTIFY maxValChanged)
     ushort getMaxVal() const { return m_maxVal; }
 
+    Q_PROPERTY(QPoint minPoint READ getMinPoint NOTIFY minPointChanged)
+    QPoint getMinPoint() const { return m_minPoint; }
+
+    Q_PROPERTY(QPoint maxPoint READ getMaxPoint NOTIFY maxPointChanged)
+    QPoint getMaxPoint() const { return m_maxPoint; }
+
 signals:
 
     void psuedocolorPaletteChanged(Palette val);
     void minValChanged(ushort val);
     void maxValChanged(ushort val);
+    void minPointChanged(QPoint point);
+    void maxPointChanged(QPoint point);
 
 private:
 
     Palette m_pseudocolor_palette;
     ushort m_minVal, m_maxVal;
+    QPoint m_minPoint, m_maxPoint;
 };
 
 #endif // DATAFORMATTER_H

--- a/qml/controls/VideoRoi.qml
+++ b/qml/controls/VideoRoi.qml
@@ -58,5 +58,16 @@ Item {
                 }
             }
         }
+        Rectangle {
+            id: maxpoint
+            x: acq.dataFormatter.maxPoint.x * (scaledvid.width / videoSize.width)
+            y: acq.dataFormatter.maxPoint.y * (scaledvid.width / videoSize.width)
+            color: "#80ff0000"
+            border.color: "#80000000"
+            width: roi.width * (scaledvid.width / videoSize.width)
+            height: roi.height * (scaledvid.height / videoSize.height)
+            visible: false
+
+          }
     }
 }

--- a/src/dataformatter.cpp
+++ b/src/dataformatter.cpp
@@ -58,15 +58,15 @@ void DataFormatter::FindMinMax(const uvc_frame_t *input, QPoint &minPoint, uint1
             if (val > maxVal)
             {
                 maxVal = val;
-                maxPoint.setX(i);
-                maxPoint.setY(j);
+                maxPoint.setX(j);
+                maxPoint.setY(i);
             }
 
             if (val < minVal)
             {
                 minVal = val;
-                minPoint.setX(i);
-                minPoint.setY(j);
+                minPoint.setX(j);
+                minPoint.setY(i);
             }
         }
     }
@@ -77,7 +77,7 @@ void DataFormatter::AutoGain(uvc_frame_t *input_output)
     uint16_t minval = 0, maxval = 0;
     QPoint minpoint, maxpoint;
     FindMinMax(input_output, minpoint, minval, maxpoint, maxval);
-    FixedGain(input_output, minval, maxval);
+    FixedGain(input_output, minpoint, minval, maxpoint, maxval);
 
     /*
     Ptr<CLAHE> clahe = createCLAHE();
@@ -90,7 +90,7 @@ void DataFormatter::AutoGain(uvc_frame_t *input_output)
     */
 }
 
-void DataFormatter::FixedGain(uvc_frame_t *input_output, ushort minval, ushort maxval)
+void DataFormatter::FixedGain(uvc_frame_t *input_output, QPoint minpoint, ushort minval, QPoint maxpoint, ushort maxval)
 {
     uint8_t bytes_per_pixel = 0;
 
@@ -141,6 +141,18 @@ void DataFormatter::FixedGain(uvc_frame_t *input_output, ushort minval, ushort m
     {
         m_maxVal = maxval;
         maxValChanged(maxval);
+    }
+
+    if (m_minPoint != minpoint)
+    {
+        m_minPoint = minpoint;
+        minPointChanged(minpoint);
+    }
+
+    if (m_maxPoint != maxpoint)
+    {
+        m_maxPoint = maxpoint;
+        maxPointChanged(maxpoint);
     }
 
 }


### PR DESCRIPTION
I added a red rectangle to indicate the maxPoint position in VideoRoi.qml. 

Note it is set as **visible: false** by default.

I used the same size as radSpotMeterRoi, I'm not sure if that makes sense.