### PR TITLE
Added support for Lepton3.1R

### DIFF
--- a/src/leptonvariation.cpp
+++ b/src/leptonvariation.cpp
@@ -138,7 +138,7 @@ bool LeptonVariation::getSupportsRadiometry()
     bool runtimeAgc = getSupportsRuntimeAgcChange();
     bool y16Firmware = getPtFirmwareVersion().contains("Y16");
     bool radiometricLepton = getOemFlirPartNumber().contains("500-0763-01")
-            || getOemFlirPartNumber().contains("500-0771-01");
+            || getOemFlirPartNumber().contains("500-0771-01") || getOemFlirPartNumber().contains("500-0758-01") ;
     return (runtimeAgc || y16Firmware) && radiometricLepton;
 }
 


### PR DESCRIPTION
Added the OEM part number for the 3.1R to the check for `bool radiometricLepton`
![image](https://github.com/groupgets/GetThermal/assets/56269216/88d56a92-362e-4a12-80f5-df7777d89030)
